### PR TITLE
feat: add v1.0.0 JSON schema contracts

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,3 +1,29 @@
 # API (Draft)
 
-Library API and schema details will be added during implementation.
+## Schema Contracts (v1.0.0)
+
+This project uses strict JSON schema contracts for both input and output.
+
+- Input schema: `docs/schema-input-v1.0.0.json`
+- Output schema: `docs/schema-output-v1.0.0.json`
+
+### Required versioning field
+
+Both input and output require:
+
+```json
+{"schemaVersion": "1.0.0"}
+```
+
+Requests/responses without `schemaVersion` or with a mismatched version must fail validation.
+
+### Validation error guidance (examples)
+
+1. Missing `schemaVersion`
+   - Error: `schemaVersion is required`
+2. Probability outside range
+   - Error: `signals[i].probability must be between 0 and 1`
+3. Unknown top-level fields
+   - Error: `additional properties are not allowed`
+
+These contracts are the compatibility baseline for v0.1.

--- a/docs/schema-input-v1.0.0.json
+++ b/docs/schema-input-v1.0.0.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/moltfounders/bayesian-consensus-engine/docs/schema-input-v1.0.0.json",
+  "title": "Bayesian Engine Input v1.0.0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "marketId", "signals"],
+  "properties": {
+    "schemaVersion": {"type": "string", "const": "1.0.0"},
+    "marketId": {"type": "string", "minLength": 1},
+    "signals": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["sourceId", "probability"],
+        "properties": {
+          "sourceId": {"type": "string", "minLength": 1},
+          "probability": {"type": "number", "minimum": 0, "maximum": 1},
+          "weightHint": {"type": "number", "minimum": 0}
+        }
+      }
+    }
+  }
+}

--- a/docs/schema-output-v1.0.0.json
+++ b/docs/schema-output-v1.0.0.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/moltfounders/bayesian-consensus-engine/docs/schema-output-v1.0.0.json",
+  "title": "Bayesian Engine Output v1.0.0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "consensus", "confidence", "sourceWeights", "normalization", "diagnostics"],
+  "properties": {
+    "schemaVersion": {"type": "string", "const": "1.0.0"},
+    "consensus": {"type": ["number", "null"], "minimum": 0, "maximum": 1},
+    "confidence": {"type": ["number", "null"], "minimum": 0, "maximum": 1},
+    "sourceWeights": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["sourceId", "weight"],
+        "properties": {
+          "sourceId": {"type": "string"},
+          "weight": {"type": "number", "minimum": 0}
+        }
+      }
+    },
+    "normalization": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "diagnostics": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+}


### PR DESCRIPTION
Closes #1

## Summary
- add `docs/schema-input-v1.0.0.json`
- add `docs/schema-output-v1.0.0.json`
- update `docs/API.md` with versioning + validation examples

## Why
Implements the first high-priority PRD alignment item: strict input/output schema contracts with required `schemaVersion`.

## Notes
This is schema+docs only; runtime validation wiring can land in a follow-up issue.